### PR TITLE
feat: Add docker-compose.yml for backend and frontend

### DIFF
--- a/docker-configs/docker-compose.yml
+++ b/docker-configs/docker-compose.yml
@@ -1,3 +1,17 @@
 version: '3.8'
 services:
-  # To be defined
+  backend:
+    build:
+      context: ../../backend
+    ports:
+      - "8000:8000"
+    command: uvicorn main:app --host 0.0.0.0 --port 8000
+  frontend:
+    build:
+      context: ../../frontend/vue-app
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    volumes:
+      - ../../frontend/vue-app:/app
+    command: npm run serve

--- a/frontend/vue-app/Dockerfile
+++ b/frontend/vue-app/Dockerfile
@@ -1,0 +1,22 @@
+# Use a Node.js base image
+FROM node:18-alpine
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy package.json and yarn.lock
+COPY yarn.lock ./
+COPY package.json ./
+
+# Install dependencies
+RUN yarn install --frozen-lockfile
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 8080
+
+# Command to run the application (already specified in docker-compose.yml, but good for documentation)
+# CMD ["npm", "run", "serve"] 
+# The command is run by docker-compose, so CMD is not strictly needed here but can be included for clarity


### PR DESCRIPTION
This commit introduces a `docker-compose.yml` file in the `docker-configs` directory to facilitate local development and testing of the backend and frontend services.

- The backend service is built from its Dockerfile in the `backend` directory and exposes port 8000.
- The frontend service is built using a new Dockerfile added in `frontend/vue-app/Dockerfile`. It uses a Node.js image, installs dependencies using Yarn, and runs the Vue.js development server on port 8080. Hot-reloading is enabled by mounting the `frontend/vue-app` directory as a volume.

This setup allows developers to easily spin up both services with a single `docker-compose up` command.