### PR TITLE
fix: Resolve backend and frontend runtime errors in Docker

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-slim
-WORKDIR /app
+WORKDIR /service
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY ./app /app
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+COPY ./app /service/app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-configs/docker-compose.yml
+++ b/docker-configs/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: ../../backend
     ports:
       - "8000:8000"
-    command: uvicorn main:app --host 0.0.0.0 --port 8000
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
   frontend:
     build:
       context: ../../frontend/vue-app
@@ -14,4 +14,4 @@ services:
       - "8080:8080"
     volumes:
       - ../../frontend/vue-app:/app
-    command: npm run serve
+    command: yarn serve


### PR DESCRIPTION
This commit addresses two primary issues encountered when running `docker-compose up`:

1.  **Backend `ModuleNotFoundError: No module named 'app'`**:
    - Modified `backend/Dockerfile` to change `WORKDIR` to `/service` and copy the application code to `/service/app`.
    - Updated the `CMD` in `backend/Dockerfile` to `uvicorn app.main:app ...`.
    - Updated the corresponding `command` in `docker-configs/docker-compose.yml` for the backend service to match `uvicorn app.main:app ...`. This ensures that the Python interpreter can correctly locate the `app` module and its submodules.

2.  **Frontend `npm error enoent`**:
    - Changed the `command` for the `frontend` service in `docker-configs/docker-compose.yml` from `npm run serve` to `yarn serve`. This aligns the command with the package manager (`yarn`) used for installing dependencies in the `frontend/vue-app/Dockerfile`, resolving script execution errors.