### PR TITLE
I've adjusted the Docker Compose context paths for clarity.

### DIFF
--- a/docker-configs/docker-compose.yml
+++ b/docker-configs/docker-compose.yml
@@ -2,16 +2,16 @@ version: '3.8'
 services:
   backend:
     build:
-      context: ../../backend
+      context: ../backend
     ports:
       - "8000:8000"
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000
   frontend:
     build:
-      context: ../../frontend/vue-app
+      context: ../frontend/vue-app
       dockerfile: Dockerfile
     ports:
       - "8080:8080"
     volumes:
-      - ../../frontend/vue-app:/app
+      - ../frontend/vue-app:/app
     command: yarn serve


### PR DESCRIPTION
I updated the build context paths in `docker-configs/docker-compose.yml` to be relative to the directory containing the compose file itself (e.g., `../backend` instead of `../../backend`).

This change makes the paths more standard for scenarios where `docker-compose` commands are run from within the `docker-configs` directory or when using `docker-compose -f docker-configs/docker-compose.yml ...` from your project root.

The volume path for the frontend service was also updated accordingly.