### PR TITLE
fix: Resolve backend and frontend runtime issues

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,4 +5,5 @@ pydantic
 sqlalchemy
 passlib[bcrypt]
 python-jose[cryptography]
+pydantic[email]
 # email-validator is commented out, can be added if needed for Pydantic's EmailStr strict validation

--- a/docker-configs/docker-compose.yml
+++ b/docker-configs/docker-compose.yml
@@ -14,4 +14,7 @@ services:
       - "8080:8080"
     volumes:
       - ../frontend/vue-app:/app
+      - node_modules_frontend:/app/node_modules
     command: yarn serve
+volumes:
+  node_modules_frontend: {}


### PR DESCRIPTION
This commit addresses two issues identified during `docker-compose up`:

1.  **Backend `ModuleNotFoundError: No module named 'email_validator'`**:
    - Added `pydantic[email]` to `backend/requirements.txt`. This ensures that the `email-validator` package, a dependency of Pydantic for email validation, is installed in the backend container.

2.  **Frontend `vue-cli-service: not found`**:
    - Modified `docker-configs/docker-compose.yml` for the frontend service to use a named volume (`node_modules_frontend`) for the `/app/node_modules` directory.
    - This prevents the host volume mount from overwriting the `node_modules` directory that was populated during the Docker image build (`yarn install`), ensuring that `vue-cli-service` and other executables are available at runtime.
    - A top-level `volumes:` key was added to `docker-compose.yml` to define the `node_modules_frontend` named volume.
    - Confirmed that no `.dockerignore` file exists in `frontend/vue-app/` that might interfere.