### PR TITLE
fix: Resolve backend TypeError and frontend ModuleNotFound

### DIFF
--- a/backend/app/crud/crud_user.py
+++ b/backend/app/crud/crud_user.py
@@ -1,11 +1,12 @@
 from sqlalchemy.orm import Session
+from typing import Optional
 from app.models import user as models_user  # Alias to avoid confusion
 from app.schemas import user as schemas_user
 from app.core.security import get_password_hash
 import uuid
 
 
-def get_user_by_email(db: Session, email: str) -> models_user.User | None:
+def get_user_by_email(db: Session, email: str) -> Optional[models_user.User]: # This line needs change
     return db.query(models_user.User).filter(models_user.User.email == email).first()
 
 

--- a/frontend/vue-app/src/views/HomeView.vue
+++ b/frontend/vue-app/src/views/HomeView.vue
@@ -1,6 +1,5 @@
 <template>
     <div class="home">
-        <img alt="Vue logo" src="../assets/logo.png">
         <HelloWorld msg="Welcome to Your Vue.js App" />
     </div>
 </template>


### PR DESCRIPTION
This commit addresses two issues identified during `docker-compose up`:

1.  **Backend `TypeError: unsupported operand type(s) for |: 'DeclarativeMeta' and 'NoneType'`**:
    - Modified `backend/app/crud/crud_user.py` to use `typing.Optional[models_user.User]` instead of the `models_user.User | None` syntax for return type hints.
    - Added `from typing import Optional` to `backend/app/crud/crud_user.py`.
    - This change ensures compatibility with Python 3.9, which is used in the backend Docker image and does not support the `|` operator for union types.

2.  **Frontend `Module not found: Error: Can't resolve '../assets/logo.png'`**:
    - Modified `frontend/vue-app/src/views/HomeView.vue` to remove the `<img ...>` tag that referenced `../assets/logo.png`.
    - This resolves the webpack build error, as the referenced image file does not exist in the specified path (`frontend/vue-app/src/assets/logo.png`).